### PR TITLE
make standard-table the default table style

### DIFF
--- a/sass/atoms/_properties-table.scss
+++ b/sass/atoms/_properties-table.scss
@@ -1,0 +1,32 @@
+@use "sass:math";
+
+/*
+ * Property tables, for an example see :
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Technical_summary
+ */
+.properties {
+  @include readable-line-length();
+  border: $standard-primary-border;
+  border-left: $property-table-border;
+  width: 100%;
+
+  th,
+  td {
+    background-color: $neutral-575;
+    border: 0;
+    border-top: $standard-primary-border;
+    display: block;
+    padding: math.div($base-spacing, 2);
+    vertical-align: top;
+
+    @media #{$mq-small-desktop-and-up} {
+      display: table-cell;
+    }
+  }
+
+  @media #{$mq-small-desktop-and-up} {
+    th {
+      min-width: 30%;
+    }
+  }
+}

--- a/sass/atoms/_tables.scss
+++ b/sass/atoms/_tables.scss
@@ -67,34 +67,3 @@ table,
     hyphens: auto;
   }
 }
-
-/*
- * Property tables, for an example see :
- * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Technical_summary
- */
-.properties {
-  @include readable-line-length();
-  border: $standard-primary-border;
-  border-left: $property-table-border;
-  width: 100%;
-
-  th,
-  td {
-    background-color: $neutral-575;
-    border: 0;
-    border-top: $standard-primary-border;
-    display: block;
-    padding: math.div($base-spacing, 2);
-    vertical-align: top;
-
-    @media #{$mq-small-desktop-and-up} {
-      display: table-cell;
-    }
-  }
-
-  @media #{$mq-small-desktop-and-up} {
-    th {
-      min-width: 30%;
-    }
-  }
-}

--- a/sass/mdn-minimalist.scss
+++ b/sass/mdn-minimalist.scss
@@ -30,6 +30,7 @@
 @import "./atoms/buttons-ghost";
 @import "./atoms/forms";
 @import "./atoms/tables";
+@import "./atoms/properties-table";
 @import "./atoms/overlays";
 @import "./atoms/utils";
 @import "./atoms/examples";


### PR DESCRIPTION
Move the properties table styles to its own atom to avoid confusion with selector override.